### PR TITLE
Add support for VZ VMs

### DIFF
--- a/lima-init.nix
+++ b/lima-init.nix
@@ -143,7 +143,9 @@ in {
             requires = [ "lima-init.service" ];
             serviceConfig = {
                 Type = "simple";
-                ExecStart = "${LIMA_CIDATA_MNT}/lima-guestagent daemon";
+                ExecStart = ''
+                    /bin/sh -c '. ${LIMA_CIDATA_MNT}/lima.env && exec ${LIMA_CIDATA_MNT}/lima-guestagent daemon --vsock-port "$LIMA_CIDATA_VSOCK_PORT"'
+                '';
                 Restart = "on-failure";
             };
         };


### PR DESCRIPTION
Fixes #1.

I added the `console=tty0` kernel parameter to fix the boot stalling issue.
I also added the `--vsock-port 2222` argument to lima-guestagent to start the guest agent on vsock port 2222 when the vmType is `vz`.

This allows me to boot with VZ, and I have migrated my development environment to Lima.