### PR TITLE
nixos.yaml: use default mountType in nixos.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ mkdir result
 ## Running NixOS
 
 ```bash
-limactl start --name=nixos nixos.yaml
+limactl start --vm-type qemu --name=nixos nixos.yaml
 
 limactl shell nixos
 ```

--- a/nixos.yaml
+++ b/nixos.yaml
@@ -19,8 +19,6 @@ mounts:
   9p:
     cache: "mmap"
 
-mountType: "9p"
-
 ssh:
   # This allows access to GitHub, etc.
   forwardAgent: true


### PR DESCRIPTION
With `mountType` no longer set to `"9p"`, Lima will default to `vmType: "vz"`, so `README.md` is updated to add `--vm-type qemu` to the `limactl start` command.

Note that `nixos-lima` doesn't support `vz` yet, but it  should be added soon and this change helps prepare for that.