### PR TITLE
build images in result-<arch> directory by default

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -30,14 +30,14 @@ jobs:
       - name: Build aarch64 Image
         if: ${{ env.HOST_ARCH == 'aarch64' }}
         run: |
-          nix build .#packages.aarch64-linux.img
-          cp result/nixos.qcow2 nixos-lima-unstable-aarch64.qcow2
+          nix build .#packages.aarch64-linux.img --out-link result-${{ env.HOST_ARCH }}
+          ln -s result-${{ env.HOST_ARCH }}/nixos.qcow2 nixos-lima-unstable-${{ env.HOST_ARCH }}.qcow2
 
       - name: Build x86_64 Image
         if: ${{ env.HOST_ARCH == 'x86_64' }}
         run: |
-          nix build .#packages.x86_64-linux.img
-          cp result/nixos.qcow2 nixos-lima-unstable-x86_64.qcow2
+          nix build .#packages.x86_64-linux.img --out-link result-${{ env.HOST_ARCH }}
+          ln -s result-${{ env.HOST_ARCH }}/nixos.qcow2 nixos-lima-unstable-${{ env.HOST_ARCH }}.qcow2
 
       - name: Upload aarch64 image as artifact
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ Flakes must be enabled.
 ## Generating the image
 
 ```bash
-nix build .#packages.aarch64-linux.img
+nix build .#packages.aarch64-linux.img --out-link result-aarch64
 ```
 
 If you built the image on another system:
 
 ```bash
-mkdir result
-# copy image to result/nixos.img
+mkdir result-aarch64
+# copy image to result-aarch64/nixos.img
 ```
 
 ## Running NixOS

--- a/nixos.yaml
+++ b/nixos.yaml
@@ -1,9 +1,9 @@
 arch: "aarch64"
 
 images:
-  - location: "./result/nixos.qcow2"
+  - location: "./result-aarch64/nixos.qcow2"
     arch: "aarch64"
-  - location: "./imgs/nixos-x86.qcow2"
+  - location: "./result-x86_64/nixos.qcow2"
     arch: "x86_64"
 
 cpus: 6


### PR DESCRIPTION
build images in result-<arch> directory by default
Update `location` in `nixos.yaml` to use the architecture in the
directory name.  (e.g. `result-aarch64`, `result-x86_64`)

Update the README and the GitHub Action to do reflect this.
