### PR TITLE
nixos.yaml: remove ssh forwardAgent

### DIFF
--- a/nixos.yaml
+++ b/nixos.yaml
@@ -19,10 +19,6 @@ mounts:
   9p:
     cache: "mmap"
 
-ssh:
-  # This allows access to GitHub, etc.
-  forwardAgent: true
-
 containerd:
   system: false
   user: false


### PR DESCRIPTION
(The default is false)

Fixes #18 