### PR TITLE
GHA build-image.yml: add test-image job, update flake, README

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -43,3 +43,82 @@ jobs:
         with:
           name: nixos-lima-unstable-${{ env.HOST_ARCH }}
           path: nixos-lima-unstable-${{ env.HOST_ARCH }}.qcow2
+
+  test-image:
+    runs-on: ${{ matrix.os }}
+    needs: build
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, macos-15]
+        guest-arch: ['aarch64', 'x86_64']
+        exclude:
+          - os: 'ubuntu-24.04'      # Dumps core with Lima > 1.0.7
+            guest-arch: 'aarch64'
+          - os: 'macos-15'          # Does not support VZ or (hw accelerated) QEMU
+            guest-arch: 'aarch64'
+          - os: 'macos-15'          # Not tested, but would require emulation
+            guest-arch: 'x86_64'
+      fail-fast: false
+    env:
+      HOST_ARCH: ${{ matrix.os == 'ubuntu-24.04' && 'x86_64' || matrix.os == 'ubuntu-24.04-arm' && 'aarch64' || matrix.os == 'macos-15' && 'aarch64' || 'unknown' }}
+      LIMA_VERSION: "v1.2.1"
+      GUEST_HOST_NAME: "nixos"
+      GUEST_USER: "lima"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download ${{ matrix.guest-arch }} image artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: nixos-lima-unstable-${{ matrix.guest-arch }}
+          path: artifacts/
+      - name: move and rename
+        run: |
+          mkdir -p result-${{ matrix.guest-arch }}
+          mv artifacts/nixos-lima-unstable-${{ matrix.guest-arch }}.qcow2 result-${{ matrix.guest-arch }}/nixos.qcow2
+
+      - name: "Install QEMU"
+        if: ${{ matrix.os == 'ubuntu-24.04' || matrix.os == 'ubuntu-24.04-arm' }}
+        run: |
+          set -eux
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ovmf qemu-system-x86 qemu-system-aarch64 qemu-efi-aarch64 qemu-utils
+          sudo modprobe kvm
+          # `sudo usermod -aG kvm $(whoami)` does not take an effect on GHA
+          if [ "${{ matrix.os }}" == "ubuntu-24.04" ]; then
+            sudo chown $(whoami) /dev/kvm
+          fi
+
+      - name: "Set up Lima (Linux)"
+        if: ${{ matrix.os == 'ubuntu-24.04' || matrix.os == 'ubuntu-24.04-arm' }}
+        uses: lima-vm/lima-actions/setup@v1
+        id: lima-actions-setup
+        with:
+          version: ${{ env.LIMA_VERSION }}
+          additional_guestagents: ${{ matrix.os == 'ubuntu-24.04' && 'false' || (matrix.os == 'ubuntu-24.04-arm' && 'true') || 'false' }}
+
+      - name: "Set up Lima (macOS)"
+        if: ${{ matrix.os == 'macos-15' }}
+        run: brew install lima
+
+      - name: "Cache ~/.cache/lima"
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/lima
+          key: os-${{ matrix.os }}-NixOS-Lima-${{ steps.lima-actions-setup.outputs.version }}-guest-${{ matrix.guest-arch }}
+
+      - name: "Start an instance of NixOS"
+        env:
+          # Use env variable QEMU_SYSTEM_AARCH64 to override Lima's QEMU configuration on aarch64 host
+          QEMU_SYSTEM_AARCH64: ${{ env.HOST_ARCH == 'aarch64' && 'qemu-system-aarch64 -machine virt -cpu max' || 'qemu-system-aarch64' }}
+        run: |
+          set -eux
+          limactl start --arch ${{ matrix.guest-arch }} --name=${{ env.GUEST_HOST_NAME }} --network=lima:user-v2 --set '.user.name = "${{ env.GUEST_USER }}"' nixos.yaml
+
+      - name: "Update and Rebuild NixOS"
+        run: |
+          set -eux
+          limactl shell nixos -- nixos-rebuild boot --flake .#nixos-${{ matrix.guest-arch }} --sudo
+          sleep 1
+          limactl stop nixos
+          limactl start nixos

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -120,5 +120,4 @@ jobs:
           set -eux
           limactl shell nixos -- nixos-rebuild boot --flake .#nixos-${{ matrix.guest-arch }} --sudo
           sleep 1
-          limactl stop nixos
-          limactl start nixos
+          limactl restart nixos

--- a/README.md
+++ b/README.md
@@ -57,16 +57,20 @@ mkdir result-aarch64
 ## Running NixOS
 
 ```bash
-limactl start --vm-type qemu --name=nixos nixos.yaml
+limactl start --yes nixos.yaml
 
 limactl shell nixos
 ```
 
 ## Rebuilding NixOS inside the Lima instance
 
+Since our `nixos.yaml` file read-only mounts the project directory and `limactl shell` by default preserves
+the current directory, we can run a `nixos-rebuild` inside the VM that references `flake.nix` in the project
+directory on the host. The following command can be set to rebuild NixOS from the local `flake.nix`:
+
 ```bash
-# Using a VM shell, cd to this repository directory
-nixos-rebuild switch --flake .#nixos --use-remote-sudo
+limactl shell nixos -- nixos-rebuild boot --flake .#nixos --sudo
+limactl restart nixos
 ```
   
 ## Managing your NiXOS Lima VM instance
@@ -76,14 +80,14 @@ See the [NixOS Lima VM Config Sample](https://github.com/nixos-lima/nixos-lima-c
 Fork and clone that repository, check it out either to your macOS host or to a directory within your NixOS VM instance. Then use:
 
 ```bash
-nixos-rebuild switch --flake .#sample --use-remote-sudo
+nixos-rebuild switch --flake .#sample --sudo
 ```
 
 Or change the name `sample` to match the hostname of your NixOS Lima guest.
 
 ## History
 
-This is a based on [kasuboski/nixos-lima](https://github.com/kasuboski/nixos-lima) and there are about a half-dozen [forks](https://github.com/kasuboski/nixos-lima/forks) of that repo, but none of them (yet) seem to be making much of an effort to be generic/reusable, accept contributions, create documentation, etc. So I created this repo to try to create something that multiple developers can use and contribute to. (So now there are a _half-dozen plus one_ projects 🤣  -- see [xkcd "Standards"](https://xkcd.com/927/))
+This is based on [kasuboski/nixos-lima](https://github.com/kasuboski/nixos-lima) and there are about a half-dozen [forks](https://github.com/kasuboski/nixos-lima/forks) of that repo, but none of them (yet) seem to be making much of an effort to be generic/reusable, accept contributions, create documentation, etc. So I created this repo to try to create something that multiple developers can use and contribute to. (So now there are a _half-dozen plus one_ projects 🤣  -- see [xkcd "Standards"](https://xkcd.com/927/))
 
 There has been ongoing discussion in https://github.com/lima-vm/lima/discussions/430, and I have proposed there to create a "unified" project. If you have input or want to collaborate, please comment there or open an issue or pull request here. I'm also happy to archive this project and contribute to another one if other collaborators think that is a better path forward.
 

--- a/flake.nix
+++ b/flake.nix
@@ -26,9 +26,16 @@
             format = "qcow-efi";
           };
         };
-      }) // { 
-        nixosConfigurations.nixos = nixpkgs.lib.nixosSystem {
-          system = "aarch64-linux"; # doesn't play nice with each system :shrug:
+      }) // {
+        nixosConfigurations.nixos-aarch64 = nixpkgs.lib.nixosSystem {
+          system = "aarch64-linux";
+          specialArgs = attrs;
+          modules = [
+            ./lima.nix
+          ];
+        };
+        nixosConfigurations.nixos-x86_64 = nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
           specialArgs = attrs;
           modules = [
             ./lima.nix


### PR DESCRIPTION
For now, GHA only seems to work reliably with the latest Lima VM running x86_64 guest on x86_64 ubuntu. `build-image.yml` tries to support aarch64 guests on x86_64 ubuntu and aarch64 guests on (aarch64) macos-15, but those tests are excluded from the matrix (until any issues can be resolved)