### PR TITLE
lima.nix: add @wheel to nix.settings.trusted-users

### DIFF
--- a/lima.nix
+++ b/lima.nix
@@ -7,6 +7,10 @@
 
     nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
+    # Give users in the `wheel` group additional rights when connecting to the Nix daemon
+    # This simplifies remote deployment to the instance's nix store.
+    nix.settings.trusted-users = [ "@wheel" ];
+
     # Read Lima configuration at boot time and run the Lima guest agent
     services.lima.enable = true;
 


### PR DESCRIPTION
By adding the wheel group to trusted-users, we enable various remote deployment tools to deploy to a newly started instance without a separate configuration step.

We use the wheel group because at the time the image is built we don't know the username the Lima will configure for SSH access to the instance.