### PR TITLE
GHA build-image test-image: don't try to upload *.sock

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -113,5 +113,6 @@ jobs:
           name: artifacts-os-${{ matrix.os }}-guest-${{ matrix.guest-arch }}-lima-errlog
           path: |
             ~/.lima/nixos/*
+            !~/.lima/nixos/*.sock
             !~/.lima/nixos/basedisk
             !~/.lima/nixos/diffdisk


### PR DESCRIPTION
Filter out *.sock filenames to prevent warning messages.