### PR TITLE
fix: make it compatible with Lima 2.1.0

### DIFF
--- a/lima-init.nix
+++ b/lima-init.nix
@@ -108,8 +108,15 @@ EOF
 
     #echo "$LIMA_CIDATA_SLIRP_GATEWAY host.lima.internal" >> /etc/hosts
 
-    cp "${LIMA_CIDATA_MNT}"/meta-data /run/lima-ssh-ready
-    cp "${LIMA_CIDATA_MNT}"/meta-data /run/lima-boot-done
+    # write instance ID to boot-done and ssh-ready signal files for Lima (>= 2.1.0)
+    if [ -n "$LIMA_CIDATA_IID" ]; then
+        echo "$LIMA_CIDATA_IID" > /run/lima-ssh-ready
+        echo "$LIMA_CIDATA_IID" > /run/lima-boot-done
+    else
+        cp "${LIMA_CIDATA_MNT}"/meta-data /run/lima-ssh-ready
+        cp "${LIMA_CIDATA_MNT}"/meta-data /run/lima-boot-done
+    fi
+
     exit 0
     '';
 in {


### PR DESCRIPTION
Because of https://github.com/lima-vm/lima/commit/6956bc66dcca4a0f39e59ffbfd6fe9b6eac720b8 , nixos-lima cannot satisfy the starting requirement `user session is ready for ssh` on Lima 2.1.0.

<details>

<summary>log (with Lima 2.1.0)</summary>

```bash
❯ limactl start github:nixos-lima --name nixos-lima   
WARN[0000] The github: scheme is still EXPERIMENTAL     
? Creating an instance "nixos-lima" Proceed with the current configuration
INFO[0003] Starting the instance "nixos-lima" with internal VM driver "vz" 
INFO[0003] Attempting to download the image              arch=aarch64 digest="sha512:a274d225c41918da7f1bb0bc1fde8cc713ed0d36954c21cc26ae403d47879a00f4c3d5601c67c647df87f6f321e1b694140b671910b15a011872311b960569b2" location="https://github.com/nixos-lima/nixos-lima/releases/download/v0.0.4/nixos-lima-v0.0.4-aarch64.qcow2"
INFO[0003] Using cache "/Users/rinx/Library/Caches/lima/download/by-url-sha256/3135d7baac16280fdcd943e7ccff4cd147d0b5377c6f18a5038f69b776ed5a4b/data" 
INFO[0003] Converting "/Users/rinx/.lima/nixos-lima/image" (qcow2) to a raw disk "/Users/rinx/.lima/nixos-lima/disk" 
4.88 GiB / 4.88 GiB [---------------------------------------] 100.00% 1.28 GiB/s
INFO[0007] Expanding to 100GiB                          
INFO[0007] [hostagent] hostagent socket created at /Users/rinx/.lima/nixos-lima/ha.sock 
INFO[0007] [hostagent] Starting VZ (hint: to watch the boot progress, see "/Users/rinx/.lima/nixos-lima/serial*.log") 
INFO[0007] [hostagent] [VZ] - vm state change: running  
INFO[0016] [hostagent] Started vsock forwarder: 127.0.0.1:52801 -> vsock:22 on VM 
INFO[0016] [hostagent] Detected SSH server is listening on the vsock port; changed 127.0.0.1:52801 to proxy for the vsock port 
INFO[0017] SSH Local Port: 52801                        
INFO[0016] [hostagent] Waiting for the essential requirement 1 of 3: "ssh" 
INFO[0016] [hostagent] The essential requirement 1 of 3 is satisfied 
INFO[0016] [hostagent] Waiting for the essential requirement 2 of 3: "user session is ready for ssh" 
FATA[0608] did not receive an event with the "running" status 
```

</details>

This PR fixes this problem.