### PR TITLE
feat(nix): use determinate nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,12 @@
       url = "github:nix-community/nixos-generators";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    /*
+      determinate = {
+        url = "github:DeterminateSystems/determinate";
+        inputs.nixpkgs.follows = "nixpkgs";
+      };
+    */
   };
   outputs =
     {
@@ -15,6 +21,7 @@
       nixpkgs-unstable,
       flake-utils,
       nixos-generators,
+      # determinate,
       ...
     }@attrs:
     # Create system-specific outputs for lima systems
@@ -31,6 +38,7 @@
           img = nixos-generators.nixosGenerate {
             inherit pkgs;
             modules = [
+              # determinate.nixosModules.default
               ./lima.nix
             ];
             format = "qcow-efi";
@@ -63,6 +71,7 @@
         system = "aarch64-linux";
         specialArgs = attrs;
         modules = [
+          # determinate.nixosModules.default
           ./lima.nix
         ];
       };
@@ -70,6 +79,7 @@
         system = "x86_64-linux";
         specialArgs = attrs;
         modules = [
+          # determinate.nixosModules.default
           ./lima.nix
         ];
       };


### PR DESCRIPTION
- [deb020c](https://github.com/nixos-lima/nixos-lima/pull/55/commits/deb020c816923bc7f8c7a0d6a74d26c23ebefd75): Fix a typo in `nixos-result.yaml`
- [815a314](https://github.com/nixos-lima/nixos-lima/pull/55/commits/815a31421933236d0fc10ee744f11e748f63d4e8): Add Determinate Nix module
- [cf02d77](https://github.com/nixos-lima/nixos-lima/pull/55/commits/cf02d7753b6a40645dd07153398f334bd6521d4c): Add `formatter` and ran `nix fmt` to format nix files. <- (Reason why it looks like there were significant changes.)

I don't want to force Determinate Nix upon this project, but if y'all are interested, [815a314](https://github.com/nixos-lima/nixos-lima/pull/55/commits/815a31421933236d0fc10ee744f11e748f63d4e8) would do it. Feel free to cherry-pick an individual commit.

