### PR TITLE
Use Lima 2.0.3 in devShell and GitHub Actions tests, nix flake update

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -59,7 +59,8 @@ jobs:
       HOST_ARCH: ${{ matrix.os == 'ubuntu-24.04' && 'x86_64' || matrix.os == 'ubuntu-24.04-arm' && 'aarch64' || matrix.os == 'macos-15' && 'aarch64' || 'unknown' }}
       GUEST_HOST_NAME: "nixos"
       GUEST_USER: "lima"
-      LIMA_VM_TYPE: ${{ matrix.os == 'macos-15' && matrix.guest-arch == 'aarch64' && '--vm-type qemu' || '' }}
+      # For macos-15, force `--vm-type qemu` since GitHub runners don't support VZ and Lima 2.0.x defaults to VZ even for x86_64 guests
+      LIMA_VM_TYPE: ${{ matrix.os == 'macos-15' && '--vm-type qemu' || '' }}
       QEMU_SYSTEM_AARCH64: ${{ matrix.os == 'ubuntu-24.04-arm' && 'qemu-system-aarch64 -machine virt -cpu max' || matrix.os == 'macos-15' && 'qemu-system-aarch64 -machine virt -cpu max' || '' }}
     steps:
       - name: Checkout

--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771043024,
-        "narHash": "sha256-O1XDr7EWbRp+kHrNNgLWgIrB0/US5wvw9K6RERWAj6I=",
+        "lastModified": 1775811116,
+        "narHash": "sha256-t+HZK42pB6N+i5RGbuy7Xluez/VvWbembBdvzsc23Ss=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3aadb7ca9eac2891d52a9dec199d9580a6e2bf44",
+        "rev": "54170c54449ea4d6725efd30d719c5e505f1c10e",
         "type": "github"
       },
       "original": {
@@ -71,11 +71,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1775823930,
-        "narHash": "sha256-ALT447J7FcxP/97J01A/gp/hgdO5lXRsm+zLMt+gIjc=",
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8c11f88bb9573a10a7d6bf87161ef08455ac70b9",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,28 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1775823930,
+        "narHash": "sha256-ALT447J7FcxP/97J01A/gp/hgdO5lXRsm+zLMt+gIjc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8c11f88bb9573a10a7d6bf87161ef08455ac70b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixos-generators": "nixos-generators",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-25.11";
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     nixos-generators = {
       url = "github:nix-community/nixos-generators";
@@ -11,6 +12,7 @@
     {
       self,
       nixpkgs,
+      nixpkgs-unstable,
       flake-utils,
       nixos-generators,
       ...
@@ -40,13 +42,16 @@
       system:
       let
         pkgs = import nixpkgs { inherit system; };
+        # Use nixpkgs-unstable to get newer Lima in devShell
+        pkgs-unstable = import nixpkgs-unstable { inherit system; };
       in
       {
         devShells.default = pkgs.mkShell {
-          packages = with pkgs; [
-            qemu
-            (lima.override {
+          packages = [
+            pkgs.qemu
+            (pkgs-unstable.lima.override {
               withAdditionalGuestAgents = true;
+              qemu = pkgs.qemu;
             })
           ];
         };


### PR DESCRIPTION
* f93101a3c38f12ca73a4bbcc8f6d6166a4e134eb 

Use nixpkgs-unstable for lima 2.0.3 in devShell, GHA
Since Lima version 1.2.2 is EOL in nixos-25.11, we need to use
nixpkgs-unstable to get Lima 2.0.3.

We override the Lima package from unstable to use the QEMU package from
nixos-25.11 (which seems to be more stable on GHA)

The generated image, configurations, and module are still built
with nixos-25.11.

GHA build-image.yml: For Lima 2.0.x on Darwin, we need to explicitly
set `--vm-type qemu` for x86_64 guests too -- because otherwise limactl
defaults to VZ which doesn't support x86_64 guest images.

* eb7a3b05c9c7c72b996eb4d901280589472c879a:

 `nix flake update`