### PR TITLE
chore(nix): update nixos-generators to use nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,42 +18,6 @@
         "type": "github"
       }
     },
-    "nixlib": {
-      "locked": {
-        "lastModified": 1736643958,
-        "narHash": "sha256-tmpqTSWVRJVhpvfSN9KXBvKEXplrwKnSZNAoNPf/S/s=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "1418bc28a52126761c02dd3d89b2d8ca0f521181",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixos-generators": {
-      "inputs": {
-        "nixlib": "nixlib",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769813415,
-        "narHash": "sha256-nnVmNNKBi1YiBNPhKclNYDORoHkuKipoz7EtVnXO50A=",
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "rev": "8946737ff703382fda7623b9fab071d037e897d5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1775811116,
@@ -88,7 +52,6 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixos-generators": "nixos-generators",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,6 @@
     nixpkgs.url = "nixpkgs/nixos-25.11";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    nixos-generators = {
-      url = "github:nix-community/nixos-generators";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
   outputs =
     {
@@ -14,30 +10,23 @@
       nixpkgs,
       nixpkgs-unstable,
       flake-utils,
-      nixos-generators,
       ...
     }@attrs:
     # Create system-specific outputs for lima systems
     let
       ful = flake-utils.lib;
     in
-    ful.eachSystem [ ful.system.x86_64-linux ful.system.aarch64-linux ] (
-      system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-      in
-      {
-        packages = {
-          img = nixos-generators.nixosGenerate {
-            inherit pkgs;
+    ful.eachSystem [ ful.system.x86_64-linux ful.system.aarch64-linux ] (system: {
+      packages = {
+        img =
+          (nixpkgs.lib.nixosSystem {
             modules = [
+              { nixpkgs.hostPlatform = system; }
               ./lima.nix
             ];
-            format = "qcow-efi";
-          };
-        };
-      }
-    )
+          }).config.system.build.images."qemu-efi";
+      };
+    })
     // ful.eachSystem [ ful.system.x86_64-linux ful.system.aarch64-linux ful.system.aarch64-darwin ] (
       system:
       let
@@ -60,16 +49,16 @@
     )
     // {
       nixosConfigurations.nixos-aarch64 = nixpkgs.lib.nixosSystem {
-        system = "aarch64-linux";
         specialArgs = attrs;
         modules = [
+          { nixpkgs.hostPlatform = "aarch64-linux"; }
           ./lima.nix
         ];
       };
       nixosConfigurations.nixos-x86_64 = nixpkgs.lib.nixosSystem {
-        system = "x86_64-linux";
         specialArgs = attrs;
         modules = [
+          { nixpkgs.hostPlatform = "x86_64-linux"; }
           ./lima.nix
         ];
       };

--- a/flake.nix
+++ b/flake.nix
@@ -19,12 +19,20 @@
     ful.eachSystem [ ful.system.x86_64-linux ful.system.aarch64-linux ] (system: {
       packages = {
         img =
-          (nixpkgs.lib.nixosSystem {
+          let
+            base = nixpkgs.lib.nixosSystem {
+              modules = [
+                { nixpkgs.hostPlatform = system; }
+                ./lima.nix
+              ];
+            };
+          in
+          (base.extendModules {
             modules = [
-              { nixpkgs.hostPlatform = system; }
-              ./lima.nix
+              "${nixpkgs}/nixos/modules/virtualisation/disk-image.nix"
+              { image.baseName = "nixos"; }
             ];
-          }).config.system.build.images."qemu-efi";
+          }).config.system.build.image;
       };
     })
     // ful.eachSystem [ ful.system.x86_64-linux ful.system.aarch64-linux ful.system.aarch64-darwin ] (


### PR DESCRIPTION
A few notes about this:
1. It changes the output file name: (Resolved by [bb957fb](https://github.com/nixos-lima/nixos-lima/pull/62/commits/bb957fb121da5576405b538addd8cb2b1e6465fe))

Current:
```bash
[developer@nixos:~/nixos-lima]$ ls result-aarch64/
nixos.qcow2  nix-support
```

New Upstream:
```bash
[developer@nixos:~/nixos-lima]$ ls result-aarch64/
nixos-image-efi-qcow2-25.11.20260410.54170c5-aarch64-linux.qcow2  nix-support
```

2. The image will now use systemd-boot instead of GRUB. The nixpkgs qemu-efi variant defaults to systemd-boot (via lib.mkDefault), while the old nixos-generators qcow-efi used GRUB. The GRUB settings in lima.nix won't cause conflicts, they're simply overridden. If you need to keep GRUB, add `boot.loader.systemd-boot.enable = false;` to lima.nix. 

I don't know the context behind why GRUB is used, and what the grub options do in [lima.nix](https://github.com/nixos-lima/nixos-lima/blob/master/lima.nix#L36), but the image built and ran fine on my M4 MacBook with lima 2.0.3.

# References
```
qemu-efi → disk-image.nix — from [nixos/modules/image/images.nix:26](https://github.com/NixOS/nixpkgs/blob/nixos-25.11/nixos/modules/image/images.nix#L26):
  qemu-efi = ../virtualisation/disk-image.nix;

disk-image.nix enables systemd-boot by default — from [nixos/modules/virtualisation/disk-image.nix:37](https://github.com/NixOS/nixpkgs/blob/nixos-25.11/nixos/modules/virtualisation/disk-image.nix#L37):
  boot.loader.systemd-boot.enable = lib.mkDefault cfg.efiSupport;
  Since qemu-efi has efiSupport = true ([the default](https://github.com/NixOS/nixpkgs/blob/nixos-25.11/nixos/modules/virtualisation/disk-image.nix#L25)), this is mkDefault true.

systemd-boot module disables GRUB — from [nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix:575](https://github.com/NixOS/nixpkgs/blob/nixos-25.11/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix#L575):
  boot.loader.grub.enable = mkDefault false;
```