### PR TITLE
feat(nix): breakout lima-init script

### DIFF
--- a/lima-init.nix
+++ b/lima-init.nix
@@ -12,125 +12,18 @@ let
 
   cfg = config.services.lima;
 
-  script = ''
-        echo "attempting to fetch configuration from LIMA user data..."
-
-        if [ -f ${LIMA_CIDATA_MNT}/lima.env ]; then
-            echo "storage exists";
-        else
-            echo "storage not exists";
-            exit 2
-        fi
-        # ripped from https://github.com/lima-vm/alpine-lima/blob/main/lima-init.sh
-        # We can't just source lima.env because values might have spaces in them
-        while read -r line; do export "$line"; done <"${LIMA_CIDATA_MNT}"/lima.env
-
-        export PATH=${
-          pkgs.lib.makeBinPath [
-            pkgs.shadow
-            pkgs.gawk
-            pkgs.mount
-          ]
-        }:$PATH
-
-        # Create user
-        id -u "$LIMA_CIDATA_USER" >/dev/null 2>&1 || useradd --home-dir "$LIMA_CIDATA_HOME" --create-home --uid "$LIMA_CIDATA_UID" "$LIMA_CIDATA_USER"
-
-        # Add user to sudoers
-        usermod -a -G wheel $LIMA_CIDATA_USER
-        usermod -a -G users $LIMA_CIDATA_USER
-
-        echo "fix symlink for /bin/bash"
-        ln -fs /run/current-system/sw/bin/bash /bin/bash
-
-        # Create authorized_keys
-        LIMA_CIDATA_SSHDIR="$LIMA_CIDATA_HOME"/.ssh
-        mkdir -p -m 700 "$LIMA_CIDATA_SSHDIR"
-        awk '
-        match($0, /^([[:space:]]*)ssh-authorized-keys:/, m) { ident="^" m[1] "[[:space:]]+-[[:space:]]+"; flag=1; next }
-        flag && $0 !~ ident { flag=0; next }
-        flag && $0 ~ ident { sub(ident, ""); gsub("\"", ""); print $0 }
-        ' "${LIMA_CIDATA_MNT}"/user-data >"$LIMA_CIDATA_SSHDIR"/authorized_keys
-        LIMA_CIDATA_GID=$(id -g "$LIMA_CIDATA_USER")
-        chown -R "$LIMA_CIDATA_UID:$LIMA_CIDATA_GID" "$LIMA_CIDATA_SSHDIR"
-        chmod 600 "$LIMA_CIDATA_SSHDIR"/authorized_keys
-
-        LIMA_SSH_KEYS_CONF=/etc/ssh/authorized_keys.d
-        mkdir -p -m 700 "$LIMA_SSH_KEYS_CONF"
-        cp "$LIMA_CIDATA_SSHDIR"/authorized_keys "$LIMA_SSH_KEYS_CONF/$LIMA_CIDATA_USER"
-
-        # Add mounts to /etc/fstab
-        echo "Adding mounts to /etc/fstab"
-        sed -i '/#LIMA-START/,/#LIMA-END/d' /etc/fstab
-        echo "#LIMA-START" >> /etc/fstab
-        awk -f- "${LIMA_CIDATA_MNT}"/user-data <<'EOF' >> /etc/fstab
-        /^mounts:/ {
-            flag = 1
-            next
-        }
-        /^[^:]*:/ {
-            flag = 0
-        }
-        /^ *$/ {
-            flag = 0
-        }
-        flag {
-            sub(/^ *- \[/, "")
-            sub(/"?\] *$/, "")
-            gsub("\"?, \"?", "\t")
-            print $0
-        }
-    EOF
-        echo "#LIMA-END" >> /etc/fstab
-
-        # Run system provisioning scripts
-        echo "Running system provisioning scripts"
-        if [ -d "${LIMA_CIDATA_MNT}"/provision.system ]; then
-        	for f in "${LIMA_CIDATA_MNT}"/provision.system/*; do
-        		echo "Executing $f"
-        		if ! "$f"; then
-        			echo "Failed to execute $f"
-        		fi
-        	done
-        fi
-
-        # Run user provisioning scripts
-        echo "Running user provisioning scripts"
-        USER_SCRIPT="$LIMA_CIDATA_HOME/.lima-user-script"
-        if [ -d "${LIMA_CIDATA_MNT}"/provision.user ]; then
-            if [ ! -f /sbin/openrc-run ]; then
-                until [ -e "/run/user/$LIMA_CIDATA_UID/systemd/private" ]; do sleep 3; done
-            fi
-            params=$(grep -o '^PARAM_[^=]*' "${LIMA_CIDATA_MNT}"/param.env | paste -sd ,)
-            for f in "${LIMA_CIDATA_MNT}"/provision.user/*; do
-                echo "Executing $f (as user $LIMA_CIDATA_USER)"
-                cp "$f" "$USER_SCRIPT"
-                chown "$LIMA_CIDATA_USER" "$USER_SCRIPT"
-                chmod 755 "$USER_SCRIPT"
-                if ! /run/wrappers/bin/sudo -iu "$LIMA_CIDATA_USER" "--preserve-env=$params" "XDG_RUNTIME_DIR=/run/user/$LIMA_CIDATA_UID" "$USER_SCRIPT"; then
-                    echo "Failed to execute $f (as user $LIMA_CIDATA_USER)"
-                fi
-                rm "$USER_SCRIPT"
-            done
-        fi
-
-
-        systemctl daemon-reload
-        systemctl restart local-fs.target
-
-        #echo "$LIMA_CIDATA_SLIRP_GATEWAY host.lima.internal" >> /etc/hosts
-
-        # write instance ID to boot-done and ssh-ready signal files for Lima (>= 2.1.0)
-        if [ -n "$LIMA_CIDATA_IID" ]; then
-            echo "$LIMA_CIDATA_IID" > /run/lima-ssh-ready
-            echo "$LIMA_CIDATA_IID" > /run/lima-boot-done
-        else
-            cp "${LIMA_CIDATA_MNT}"/meta-data /run/lima-ssh-ready
-            cp "${LIMA_CIDATA_MNT}"/meta-data /run/lima-boot-done
-        fi
-
-        exit 0
-  '';
+  script =
+    lib.replaceStrings
+      [ "@limaCidataMnt@" "@binPath@" ]
+      [
+        LIMA_CIDATA_MNT
+        (pkgs.lib.makeBinPath [
+          pkgs.shadow
+          pkgs.gawk
+          pkgs.mount
+        ])
+      ]
+      (builtins.readFile ./lima-init.sh);
 in
 {
   imports = [ ];

--- a/lima-init.sh
+++ b/lima-init.sh
@@ -1,0 +1,111 @@
+echo "attempting to fetch configuration from LIMA user data..."
+
+if [ -f @limaCidataMnt@/lima.env ]; then
+    echo "storage exists";
+else
+    echo "storage not exists";
+    exit 2
+fi
+# ripped from https://github.com/lima-vm/alpine-lima/blob/main/lima-init.sh
+# We can't just source lima.env because values might have spaces in them
+while read -r line; do export "$line"; done <"@limaCidataMnt@"/lima.env
+
+export PATH=@binPath@:$PATH
+
+# Create user
+id -u "$LIMA_CIDATA_USER" >/dev/null 2>&1 || useradd --home-dir "$LIMA_CIDATA_HOME" --create-home --uid "$LIMA_CIDATA_UID" "$LIMA_CIDATA_USER"
+
+# Add user to sudoers
+usermod -a -G wheel $LIMA_CIDATA_USER
+usermod -a -G users $LIMA_CIDATA_USER
+
+echo "fix symlink for /bin/bash"
+ln -fs /run/current-system/sw/bin/bash /bin/bash
+
+# Create authorized_keys
+LIMA_CIDATA_SSHDIR="$LIMA_CIDATA_HOME"/.ssh
+mkdir -p -m 700 "$LIMA_CIDATA_SSHDIR"
+awk '
+match($0, /^([[:space:]]*)ssh-authorized-keys:/, m) { ident="^" m[1] "[[:space:]]+-[[:space:]]+"; flag=1; next }
+flag && $0 !~ ident { flag=0; next }
+flag && $0 ~ ident { sub(ident, ""); gsub("\"", ""); print $0 }
+' "@limaCidataMnt@"/user-data >"$LIMA_CIDATA_SSHDIR"/authorized_keys
+LIMA_CIDATA_GID=$(id -g "$LIMA_CIDATA_USER")
+chown -R "$LIMA_CIDATA_UID:$LIMA_CIDATA_GID" "$LIMA_CIDATA_SSHDIR"
+chmod 600 "$LIMA_CIDATA_SSHDIR"/authorized_keys
+
+LIMA_SSH_KEYS_CONF=/etc/ssh/authorized_keys.d
+mkdir -p -m 700 "$LIMA_SSH_KEYS_CONF"
+cp "$LIMA_CIDATA_SSHDIR"/authorized_keys "$LIMA_SSH_KEYS_CONF/$LIMA_CIDATA_USER"
+
+# Add mounts to /etc/fstab
+echo "Adding mounts to /etc/fstab"
+sed -i '/#LIMA-START/,/#LIMA-END/d' /etc/fstab
+echo "#LIMA-START" >> /etc/fstab
+awk -f- "@limaCidataMnt@"/user-data <<'EOF' >> /etc/fstab
+/^mounts:/ {
+    flag = 1
+    next
+}
+/^[^:]*:/ {
+    flag = 0
+}
+/^ *$/ {
+    flag = 0
+}
+flag {
+    sub(/^ *- \[/, "")
+    sub(/"?\] *$/, "")
+    gsub("\"?, \"?", "\t")
+    print $0
+}
+EOF
+echo "#LIMA-END" >> /etc/fstab
+
+# Run system provisioning scripts
+echo "Running system provisioning scripts"
+if [ -d "@limaCidataMnt@"/provision.system ]; then
+for f in "@limaCidataMnt@"/provision.system/*; do
+    echo "Executing $f"
+    if ! "$f"; then
+        echo "Failed to execute $f"
+    fi
+done
+fi
+
+# Run user provisioning scripts
+echo "Running user provisioning scripts"
+USER_SCRIPT="$LIMA_CIDATA_HOME/.lima-user-script"
+if [ -d "@limaCidataMnt@"/provision.user ]; then
+    if [ ! -f /sbin/openrc-run ]; then
+        until [ -e "/run/user/$LIMA_CIDATA_UID/systemd/private" ]; do sleep 3; done
+    fi
+    params=$(grep -o '^PARAM_[^=]*' "@limaCidataMnt@"/param.env | paste -sd ,)
+    for f in "@limaCidataMnt@"/provision.user/*; do
+        echo "Executing $f (as user $LIMA_CIDATA_USER)"
+        cp "$f" "$USER_SCRIPT"
+        chown "$LIMA_CIDATA_USER" "$USER_SCRIPT"
+        chmod 755 "$USER_SCRIPT"
+        if ! /run/wrappers/bin/sudo -iu "$LIMA_CIDATA_USER" "--preserve-env=$params" "XDG_RUNTIME_DIR=/run/user/$LIMA_CIDATA_UID" "$USER_SCRIPT"; then
+            echo "Failed to execute $f (as user $LIMA_CIDATA_USER)"
+        fi
+        rm "$USER_SCRIPT"
+    done
+fi
+
+
+systemctl daemon-reload
+systemctl restart local-fs.target
+
+#echo "$LIMA_CIDATA_SLIRP_GATEWAY host.lima.internal" >> /etc/hosts
+
+# write instance ID to boot-done and ssh-ready signal files for Lima (>= 2.1.0)
+if [ -n "$LIMA_CIDATA_IID" ]; then
+    echo "$LIMA_CIDATA_IID" > /run/lima-ssh-ready
+    echo "$LIMA_CIDATA_IID" > /run/lima-boot-done
+else
+    cp "@limaCidataMnt@"/meta-data /run/lima-ssh-ready
+    cp "@limaCidataMnt@"/meta-data /run/lima-boot-done
+fi
+
+exit 0


### PR DESCRIPTION
- Moves the lima-init script to it's own file. 
- Adds shellcheck to the dev shell
- Read `lima-init.sh` from `lima-init.nix` with string replacement (to populate variables)

Used `lib.replaceStrings` instead of `pkgs.substitute` like https://github.com/charles-dyfis-net/nixos-lima/commit/a4d5d08d555a9e98ad2e8e25253c21f3da8c2be5 because it's simpler and (to the best of my knowledge) we do not need the script to be a standalone executable in the Nix store and do not have substitution variables that are themselves derivation outputs (where build-time ordering matters).


Built and run using lima 2.0.3:

```bash
[lima@nixos:~]$ systemctl status lima-init
● lima-init.service - Reconfigure the system from lima-init userdata on startup
     Loaded: loaded (/etc/systemd/system/lima-init.service; linked; preset: ignored)
     Active: active (exited) since Mon 2026-04-13 01:17:33 UTC; 19s ago
 Invocation: 7edfafcd367e4a0f9621b475a3cb0787
    Process: 777 ExecStart=/nix/store/av1l5q52ff4wa2yf0sw56y7jrk7ykv1x-unit-script-lima-init-start/bin/lima-init-start (code=exited>
   Main PID: 777 (code=exited, status=0/SUCCESS)
         IP: 0B in, 0B out
         IO: 882K read, 72K written
   Mem peak: 4.4M
        CPU: 23ms

Apr 13 01:17:33 nixos lima-init-start[777]: storage exists
Apr 13 01:17:33 nixos lima-init-start[782]: useradd warning: lima's uid 502 outside of the UID_MIN 1000 and UID_MAX 29999 range.
Apr 13 01:17:33 nixos useradd[782]: new user: name=lima, UID=502, GID=100, home=/home/lima.linux, shell=/run/current-system/sw/bin/>
Apr 13 01:17:33 nixos usermod[807]: add 'lima' to group 'wheel'
Apr 13 01:17:33 nixos usermod[831]: add 'lima' to group 'users'
Apr 13 01:17:33 nixos lima-init-start[777]: fix symlink for /bin/bash
Apr 13 01:17:33 nixos lima-init-start[777]: Adding mounts to /etc/fstab
Apr 13 01:17:33 nixos lima-init-start[777]: Running system provisioning scripts
Apr 13 01:17:33 nixos lima-init-start[777]: Running user provisioning scripts
Apr 13 01:17:33 nixos systemd[1]: Finished Reconfigure the system from lima-init userdata on startup.
lines 1-21/21 (END)
```