### PR TITLE
GHA build-image.yml: add `on merge_group`, remove `on push`.

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,6 +1,6 @@
 name: Build NixOS Lima Image
 
-on: [workflow_dispatch, push, pull_request]
+on: [pull_request, merge_group, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
`on merge_group` is needed to support the GitHub Merge Queue feature.

`on push` is causing us to run two checks for every push that is part of a pull request, which is wasteful of resources.