### PR TITLE
GHA build-image.yml: remove nix_path setting from install-nix-action

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -27,7 +27,6 @@ jobs:
           # Use env variable QEMU_SYSTEM_AARCH64 to override Lima's QEMU configuration on aarch64 host
           SYSTEM_FEATURES: ${{ env.HOST_ARCH == 'aarch64' && 'kvm aarch64-linux' || 'kvm' }}
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             system-features = ${{ env.SYSTEM_FEATURES }}
           github_access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since we are using flakes this setting is unneeded/unused.