### PR TITLE
(TEST) flake.nix: use nixos-unstable-small (for Lima v2.1.3)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-26.05";
+    nixpkgs.url = "nixpkgs/nixos-unstable-small";
     flake-utils.url = "github:numtide/flake-utils";
     nixos-generators = {
       url = "github:nix-community/nixos-generators";


### PR DESCRIPTION
This is a test branch to use Lima 2.1.3 which is currently available on  nixos-unstable-small.

To track the Lima 2.1.3 PR see: https://nixpk.gs/pr-tracker.html?pr=533308