### PR TITLE
GHA build-image.yml: exclude `disk` from uploaded log artifacts

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -115,5 +115,6 @@ jobs:
           path: |
             ~/.lima/nixos/*
             !~/.lima/nixos/*.sock
+            !~/.lima/nixos/disk
             !~/.lima/nixos/basedisk
             !~/.lima/nixos/diffdisk


### PR DESCRIPTION
We were previously excluding `basedisk` and `diffdisk` but Lima now uses `disk` instead.