### PR TITLE
GHA build-image.yml: use hvf for aarch64 guest on macos-15

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -60,7 +60,7 @@ jobs:
       GUEST_USER: "lima"
       # For macos-15, force `--vm-type qemu` since GitHub runners don't support VZ and Lima 2.0.x defaults to VZ even for x86_64 guests
       LIMA_VM_TYPE: ${{ matrix.os == 'macos-15' && '--vm-type qemu' || '' }}
-      QEMU_SYSTEM_AARCH64: ${{ matrix.os == 'ubuntu-26.04-arm' && 'qemu-system-aarch64 -machine virt -cpu max' || matrix.os == 'macos-15' && 'qemu-system-aarch64 -machine virt -cpu max' || '' }}
+      QEMU_SYSTEM_AARCH64: ${{ matrix.os == 'ubuntu-26.04-arm' && 'qemu-system-aarch64 -machine virt -cpu max' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -92,9 +92,6 @@ jobs:
 
       - name: "Start an instance of NixOS"
         shell: 'nix develop -c bash -e {0}'
-        env:
-          # Use env variable QEMU_SYSTEM_AARCH64 to override Lima's QEMU configuration on aarch64 host
-          QEMU_SYSTEM_AARCH64: ${{ env.HOST_ARCH == 'aarch64' && 'qemu-system-aarch64 -machine virt -cpu max' || 'qemu-system-aarch64' }}
         run: |
           set -eux
           limactl start ${{ env.LIMA_VM_TYPE }} --arch ${{ matrix.guest-arch }} --name=${{ env.GUEST_HOST_NAME }} --network=lima:user-v2 --set '.user.name = "${{ env.GUEST_USER }}"' nixos-result.yaml


### PR DESCRIPTION
Remove the step-level (redundant) definition of QEMU_SYSTEM_AARCH64 and don't override QEMU_SYSTEM_AARCH64 for macos-15. This should result in hvf being used for aarch64 guest on macos-15.