### PR TITLE
GHA build-image.yml: Remove redundant definition of QEMU_SYSTEM_AARCH64

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -92,9 +92,6 @@ jobs:
 
       - name: "Start an instance of NixOS"
         shell: 'nix develop -c bash -e {0}'
-        env:
-          # Use env variable QEMU_SYSTEM_AARCH64 to override Lima's QEMU configuration on aarch64 host
-          QEMU_SYSTEM_AARCH64: ${{ env.HOST_ARCH == 'aarch64' && 'qemu-system-aarch64 -machine virt -cpu max' || 'qemu-system-aarch64' }}
         run: |
           set -eux
           limactl start ${{ env.LIMA_VM_TYPE }} --arch ${{ matrix.guest-arch }} --name=${{ env.GUEST_HOST_NAME }} --network=lima:user-v2 --set '.user.name = "${{ env.GUEST_USER }}"' nixos-result.yaml


### PR DESCRIPTION
Remove the step-level (redundant) definition of QEMU_SYSTEM_AARCH64.